### PR TITLE
AGS 3.6.0 support + .NET 6

### DIFF
--- a/AGSUnpacker.CLI/AGSUnpacker.CLI.csproj
+++ b/AGSUnpacker.CLI/AGSUnpacker.CLI.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/AGSUnpacker.Graphics.GDI/AGSUnpacker.Graphics.GDI.csproj
+++ b/AGSUnpacker.Graphics.GDI/AGSUnpacker.Graphics.GDI.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>AGSUnpacker.Graphics</AssemblyName>
   </PropertyGroup>
 

--- a/AGSUnpacker.Graphics/Color.cs
+++ b/AGSUnpacker.Graphics/Color.cs
@@ -1,4 +1,8 @@
-﻿namespace AGSUnpacker.Graphics
+﻿using System;
+
+using AGSUnpacker.Graphics.Formats;
+
+namespace AGSUnpacker.Graphics
 {
   public struct Color
   {
@@ -33,6 +37,117 @@
       byte alpha = (byte)((rgba32 >> 24) & 0xFF);
 
       return new Color(red, green, blue, alpha);
+    }
+  }
+
+  public static class ColorExtension
+  {
+    public static byte[] ToBuffer(this Color[] colors, PixelFormat format)
+    {
+      switch (format)
+      {
+        case PixelFormat.Rgb565:
+          return colors.ToRgb565();
+
+        case PixelFormat.Rgb666:
+        case PixelFormat.Rgb24:
+          return colors.ToRgb24(format);
+
+        case PixelFormat.Argb6666:
+        case PixelFormat.Argb32:
+          return colors.ToRgba32(format);
+
+        default:
+          throw new NotSupportedException("Not supported palette format!");
+      }
+    }
+
+    private static byte[] ToRgb565(this Color[] colors)
+    {
+      int bytesPerPixel = 2;
+
+      byte[] buffer = new byte[colors.Length * bytesPerPixel];
+
+      for (int i = 0; i < colors.Length; ++i)
+      {
+        int red   = colors[i].R;
+        int green = colors[i].G;
+        int blue  = colors[i].B;
+
+        red   = (int)((red   / 256f) * 32);
+        green = (int)((green / 256f) * 64);
+        blue  = (int)((blue  / 256f) * 32);
+
+        // NOTE(adm244): little-endian bgr565 format
+        UInt16 value = (UInt16)((byte)(blue << 11) | (byte)(green << 5) | (byte)(red));
+
+        buffer[bytesPerPixel * i + 0] = (byte)(value >> 8);
+        buffer[bytesPerPixel * i + 1] = (byte)(value);
+      }
+
+      return buffer;
+    }
+
+    private static byte[] ToRgb24(this Color[] colors, PixelFormat format)
+    {
+      int bytesPerPixel = format.GetBytesPerPixel();
+      if (bytesPerPixel != 3)
+        throw new ArgumentException("Invalid color format for RGB!");
+
+      byte[] buffer = new byte[colors.Length * bytesPerPixel];
+
+      for (int i = 0; i < colors.Length; ++i)
+      {
+        int red   = colors[i].R;
+        int green = colors[i].G;
+        int blue  = colors[i].B;
+
+        if (format == PixelFormat.Rgb666)
+        {
+          //TODO(adm244): consider moving this into MathUtils or something
+          red   = (int)((red   / 256f) * 64f);
+          green = (int)((green / 256f) * 64f);
+          blue  = (int)((blue  / 256f) * 64f);
+        }
+
+        buffer[bytesPerPixel * i + 0] = (byte)red;
+        buffer[bytesPerPixel * i + 1] = (byte)green;
+        buffer[bytesPerPixel * i + 2] = (byte)blue;
+      }
+
+      return buffer;
+    }
+
+    private static byte[] ToRgba32(this Color[] colors, PixelFormat format)
+    {
+      int bytesPerPixel = format.GetBytesPerPixel();
+      if (bytesPerPixel != 4)
+        throw new ArgumentException("Invalid color format for RGBA!");
+
+      byte[] buffer = new byte[colors.Length * bytesPerPixel];
+
+      for (int i = 0; i < colors.Length; ++i)
+      {
+        int red   = colors[i].R;
+        int green = colors[i].G;
+        int blue  = colors[i].B;
+        int alpha = colors[i].A;
+
+        if (format == PixelFormat.Argb6666)
+        {
+          red   = (int)((red   / 256f) * 64f);
+          green = (int)((green / 256f) * 64f);
+          blue  = (int)((blue  / 256f) * 64f);
+          alpha = (int)((alpha / 256f) * 64f);
+        }
+
+        buffer[bytesPerPixel * i + 0] = (byte)red;
+        buffer[bytesPerPixel * i + 1] = (byte)green;
+        buffer[bytesPerPixel * i + 2] = (byte)blue;
+        buffer[bytesPerPixel * i + 3] = (byte)alpha;
+      }
+
+      return buffer;
     }
   }
 }

--- a/AGSUnpacker.Graphics/Palette.cs
+++ b/AGSUnpacker.Graphics/Palette.cs
@@ -23,6 +23,7 @@ namespace AGSUnpacker.Graphics
     public PixelFormat? SourceFormat { get; }
     public Color[] Entries { get; }
     public int Length => Entries.Length;
+    public bool Empty => Entries.Length == 0;
 
     public Color this[int index] => Entries[index];
 
@@ -36,82 +37,87 @@ namespace AGSUnpacker.Graphics
 
     public byte[] ToBuffer(PixelFormat format)
     {
-      switch (format)
-      {
-        case PixelFormat.Rgb666:
-        case PixelFormat.Rgb24:
-          return ToRgb(format);
-
-        case PixelFormat.Argb6666:
-        case PixelFormat.Argb32:
-          return ToRgba(format);
-
-        default:
-          throw new NotSupportedException("Not supported palette format!");
-      }
+      return Entries.ToBuffer(format);
     }
 
-    private byte[] ToRgb(PixelFormat format)
-    {
-      int bytesPerPixel = format.GetBytesPerPixel();
-      if (bytesPerPixel != 3)
-        throw new ArgumentException("Invalid color format for RGB!");
-
-      byte[] buffer = new byte[Entries.Length * bytesPerPixel];
-
-      for (int i = 0; i < Entries.Length; ++i)
-      {
-        int red   = Entries[i].R;
-        int green = Entries[i].G;
-        int blue  = Entries[i].B;
-
-        if (format == PixelFormat.Rgb666)
-        {
-          //TODO(adm244): consider moving this into MathUtils or something
-          red   = (int)((red   / 256f) * 64f);
-          green = (int)((green / 256f) * 64f);
-          blue  = (int)((blue  / 256f) * 64f);
-        }
-
-        buffer[bytesPerPixel * i + 0] = (byte)red;
-        buffer[bytesPerPixel * i + 1] = (byte)green;
-        buffer[bytesPerPixel * i + 2] = (byte)blue;
-      }
-
-      return buffer;
-    }
-
-    private byte[] ToRgba(PixelFormat format)
-    {
-      int bytesPerPixel = format.GetBytesPerPixel();
-      if (bytesPerPixel != 4)
-        throw new ArgumentException("Invalid color format for RGBA!");
-
-      byte[] buffer = new byte[Entries.Length * bytesPerPixel];
-
-      for (int i = 0; i < Entries.Length; ++i)
-      {
-        int red   = Entries[i].R;
-        int green = Entries[i].G;
-        int blue  = Entries[i].B;
-        int alpha = Entries[i].A;
-
-        if (format == PixelFormat.Argb6666)
-        {
-          red   = (int)((red   / 256f) * 64f);
-          green = (int)((green / 256f) * 64f);
-          blue  = (int)((blue  / 256f) * 64f);
-          alpha = (int)((alpha / 256f) * 64f);
-        }
-
-        buffer[bytesPerPixel * i + 0] = (byte)red;
-        buffer[bytesPerPixel * i + 1] = (byte)green;
-        buffer[bytesPerPixel * i + 2] = (byte)blue;
-        buffer[bytesPerPixel * i + 3] = (byte)alpha;
-      }
-
-      return buffer;
-    }
+    //public byte[] ToBuffer(PixelFormat format)
+    //{
+    //  switch (format)
+    //  {
+    //    case PixelFormat.Rgb666:
+    //    case PixelFormat.Rgb24:
+    //      return ToRgb(format);
+    //
+    //    case PixelFormat.Argb6666:
+    //    case PixelFormat.Argb32:
+    //      return ToRgba(format);
+    //
+    //    default:
+    //      throw new NotSupportedException("Not supported palette format!");
+    //  }
+    //}
+    //
+    //private byte[] ToRgb(PixelFormat format)
+    //{
+    //  int bytesPerPixel = format.GetBytesPerPixel();
+    //  if (bytesPerPixel != 3)
+    //    throw new ArgumentException("Invalid color format for RGB!");
+    //
+    //  byte[] buffer = new byte[Entries.Length * bytesPerPixel];
+    //
+    //  for (int i = 0; i < Entries.Length; ++i)
+    //  {
+    //    int red   = Entries[i].R;
+    //    int green = Entries[i].G;
+    //    int blue  = Entries[i].B;
+    //
+    //    if (format == PixelFormat.Rgb666)
+    //    {
+    //      //TODO(adm244): consider moving this into MathUtils or something
+    //      red   = (int)((red   / 256f) * 64f);
+    //      green = (int)((green / 256f) * 64f);
+    //      blue  = (int)((blue  / 256f) * 64f);
+    //    }
+    //
+    //    buffer[bytesPerPixel * i + 0] = (byte)red;
+    //    buffer[bytesPerPixel * i + 1] = (byte)green;
+    //    buffer[bytesPerPixel * i + 2] = (byte)blue;
+    //  }
+    //
+    //  return buffer;
+    //}
+    //
+    //private byte[] ToRgba(PixelFormat format)
+    //{
+    //  int bytesPerPixel = format.GetBytesPerPixel();
+    //  if (bytesPerPixel != 4)
+    //    throw new ArgumentException("Invalid color format for RGBA!");
+    //
+    //  byte[] buffer = new byte[Entries.Length * bytesPerPixel];
+    //
+    //  for (int i = 0; i < Entries.Length; ++i)
+    //  {
+    //    int red   = Entries[i].R;
+    //    int green = Entries[i].G;
+    //    int blue  = Entries[i].B;
+    //    int alpha = Entries[i].A;
+    //
+    //    if (format == PixelFormat.Argb6666)
+    //    {
+    //      red   = (int)((red   / 256f) * 64f);
+    //      green = (int)((green / 256f) * 64f);
+    //      blue  = (int)((blue  / 256f) * 64f);
+    //      alpha = (int)((alpha / 256f) * 64f);
+    //    }
+    //
+    //    buffer[bytesPerPixel * i + 0] = (byte)red;
+    //    buffer[bytesPerPixel * i + 1] = (byte)green;
+    //    buffer[bytesPerPixel * i + 2] = (byte)blue;
+    //    buffer[bytesPerPixel * i + 3] = (byte)alpha;
+    //  }
+    //
+    //  return buffer;
+    //}
 
     public static Palette FromBuffer(byte[] buffer, PixelFormat format)
     {

--- a/AGSUnpacker.Graphics/Palette.cs
+++ b/AGSUnpacker.Graphics/Palette.cs
@@ -186,6 +186,7 @@ namespace AGSUnpacker.Graphics
           //alpha = (byte)((alpha / 64f) * 256f);
         }
 
+        //FIXME(adm244): add alpha-channel support back
         colors[i] = new Color(red, green, blue, 255);
       }
 

--- a/AGSUnpacker.Graphics/Palette.cs
+++ b/AGSUnpacker.Graphics/Palette.cs
@@ -119,7 +119,7 @@ namespace AGSUnpacker.Graphics
     //  return buffer;
     //}
 
-    public static Palette FromBuffer(byte[] buffer, PixelFormat format)
+    public static Palette FromBuffer(byte[] buffer, PixelFormat format, bool discardAlpha = true)
     {
       switch (format)
       {
@@ -129,7 +129,7 @@ namespace AGSUnpacker.Graphics
 
         case PixelFormat.Argb6666:
         case PixelFormat.Argb32:
-          return FromRgba(buffer, format);
+          return FromRgba(buffer, format, discardAlpha);
 
         default:
           throw new NotSupportedException("Not supported palette format!");
@@ -163,7 +163,7 @@ namespace AGSUnpacker.Graphics
       return new Palette(colors, format);
     }
 
-    private static Palette FromRgba(byte[] buffer, PixelFormat format)
+    private static Palette FromRgba(byte[] buffer, PixelFormat format, bool discardAlpha = true)
     {
       int bytesPerPixel = format.GetBytesPerPixel();
       if (bytesPerPixel != 4)
@@ -176,18 +176,20 @@ namespace AGSUnpacker.Graphics
         byte red   = buffer[bytesPerPixel * i + 0];
         byte green = buffer[bytesPerPixel * i + 1];
         byte blue  = buffer[bytesPerPixel * i + 2];
-        //byte alpha = buffer[bytesPerPixel * i + 3];
+        byte alpha = buffer[bytesPerPixel * i + 3];
 
         if (format == PixelFormat.Argb6666)
         {
           red   = (byte)((red   / 64f) * 256f);
           green = (byte)((green / 64f) * 256f);
           blue  = (byte)((blue  / 64f) * 256f);
-          //alpha = (byte)((alpha / 64f) * 256f);
+          alpha = (byte)((alpha / 64f) * 256f);
         }
 
-        //FIXME(adm244): add alpha-channel support back
-        colors[i] = new Color(red, green, blue, 255);
+        if (discardAlpha)
+          alpha = 255;
+
+        colors[i] = new Color(red, green, blue, alpha);
       }
 
       return new Palette(colors, format);

--- a/AGSUnpacker.Lib/AGSUnpacker.Lib.csproj
+++ b/AGSUnpacker.Lib/AGSUnpacker.Lib.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Version>0.6.0</Version>
     <Authors>AdM244</Authors>
   </PropertyGroup>

--- a/AGSUnpacker.Lib/Game/AGSCursorInfo.cs
+++ b/AGSUnpacker.Lib/Game/AGSCursorInfo.cs
@@ -11,6 +11,9 @@ namespace AGSUnpacker.Lib
     public string name;
     public byte flags;
 
+    // extension data
+    public int animdelay;
+
     public AGSCursorInfo()
     {
       picture = 0;
@@ -19,6 +22,8 @@ namespace AGSUnpacker.Lib
       view = 0;
       name = string.Empty;
       flags = 0;
+
+      animdelay = 5;
     }
 
     public void LoadFromStream(AGSAlignedStream ar)

--- a/AGSUnpacker.Lib/Game/AGSGameData.cs
+++ b/AGSUnpacker.Lib/Game/AGSGameData.cs
@@ -370,7 +370,8 @@ namespace AGSUnpacker.Lib.Game
         //NOTE(adm244): don't try to read extension blocks if at the eof
         if (r.BaseStream.Position < r.BaseStream.Length)
         {
-          ExtensionBlock.ReadMultiple(r, ReadExtensionBlock);
+          ExtensionBlock.ReadMultiple(r, ReadExtensionBlock,
+            ExtensionBlock.Options.Id8 | ExtensionBlock.Options.Size64);
         }
       }
     }

--- a/AGSUnpacker.Lib/Game/AGSGameData.cs
+++ b/AGSUnpacker.Lib/Game/AGSGameData.cs
@@ -6,6 +6,7 @@ using System.Text;
 
 using AGSUnpacker.Lib.Game.View;
 using AGSUnpacker.Lib.Shared;
+using AGSUnpacker.Lib.Shared.FormatExtensions;
 using AGSUnpacker.Lib.Shared.Interaction;
 using AGSUnpacker.Shared.Extensions;
 using AGSUnpacker.Shared.Utils.Encryption;
@@ -31,6 +32,8 @@ namespace AGSUnpacker.Lib.Game
     public char[] save_folder;
     public byte[] font_flags;
     public byte[] font_outlines;
+    public int[] font_outlines_thickness;
+    public int[] font_outlines_style;
     public byte[] sprite_flags;
     public AGSInventoryItem[] inventoryItems;
     public AGSCursorInfo[] cursors;
@@ -66,6 +69,8 @@ namespace AGSUnpacker.Lib.Game
       save_folder = new char[0];
       font_flags = new byte[0];
       font_outlines = new byte[0];
+      font_outlines_thickness = new int[0];
+      font_outlines_style = new int[0];
       sprite_flags = new byte[0];
       inventoryItems = new AGSInventoryItem[0];
       cursors = new AGSCursorInfo[0];
@@ -358,6 +363,63 @@ namespace AGSUnpacker.Lib.Game
       if (dta_version >= 36) // 2.8 ???
       {
         ParseRoomsDebugInfo(r);
+      }
+
+      if (dta_version > 50) // > 3.5.0
+      {
+        //NOTE(adm244): don't try to read extension blocks if at the eof
+        if (r.BaseStream.Position < r.BaseStream.Length)
+        {
+          ExtensionBlock.ReadMultiple(r, ReadExtensionBlock);
+        }
+      }
+    }
+
+    private bool ReadFontsExtensionBlock(BinaryReader reader)
+    {
+      font_outlines_thickness = new int[setup.fonts_count];
+      font_outlines_style = new int[setup.fonts_count];
+
+      for (int i = 0; i < setup.fonts_count; ++i)
+      {
+        font_outlines_thickness[i] = reader.ReadInt32();
+        font_outlines_style[i] = reader.ReadInt32();
+
+        //NOTE(adm244): skip over reserved ints
+        // (btw, why do they reserve space if there's block size right there
+        //  and it's trivial to skip over unknown options and add extra stuff?)
+        reader.BaseStream.Seek(4 * sizeof(Int32), SeekOrigin.Current);
+      }
+
+      return true;
+    }
+
+    private bool ReadCursorsExtensionBlock(BinaryReader reader)
+    {
+      for (int i = 0; i < setup.cursors_count; ++i)
+      {
+        cursors[i].animdelay = reader.ReadInt32();
+
+        //NOTE(adm244): skip over reserved ints
+        reader.BaseStream.Seek(3 * sizeof(Int32), SeekOrigin.Current);
+      }
+
+      return true;
+    }
+
+    private bool ReadExtensionBlock(BinaryReader reader, string id, long size)
+    {
+      switch (id)
+      {
+        case "v360_fonts":
+          return ReadFontsExtensionBlock(reader);
+
+        case "v360_cursors":
+          return ReadCursorsExtensionBlock(reader);
+
+        default:
+          Debug.Assert(false, $"Data extension block '{id}' is not supported!");
+          return false;
       }
     }
 

--- a/AGSUnpacker.Lib/Graphics/AGSGraphics.cs
+++ b/AGSUnpacker.Lib/Graphics/AGSGraphics.cs
@@ -161,7 +161,7 @@ namespace AGSUnpacker.Lib.Graphics
 
       // TODO(adm244): use stream write to directly write size and pixel data
       byte[] buffer = PreAppendImageSize(image.Width, image.Height, bytesPerPixel, pixels);
-      byte[] bufferCompressed = AGSCompression.LZ77Compress(buffer);
+      byte[] bufferCompressed = AGSCompression.WriteLZ77(buffer);
 
       writer.Write((UInt32)buffer.Length);
       writer.Write((UInt32)bufferCompressed.Length);

--- a/AGSUnpacker.Lib/Graphics/AGSSpriteSet.cs
+++ b/AGSUnpacker.Lib/Graphics/AGSSpriteSet.cs
@@ -702,8 +702,8 @@ namespace AGSUnpacker.Lib.Graphics
 
       byte[] pixels;
       if (compression == CompressionType.RLE)
-        //NOTE(adm244): double check 'bytesPerPixel' value if sprite is indexed
-        pixels = DecompressRLE(reader, sizeUncompressed, bytesPerPixel);
+        pixels = DecompressRLE(reader, sizeUncompressed,
+          format != SpriteFormat.Default ? 1 : bytesPerPixel);
       else if (compression == CompressionType.LZW)
         pixels = DecompressLZW(reader, sizeUncompressed);
       else if (compression == CompressionType.Uncompressed)

--- a/AGSUnpacker.Lib/Graphics/AGSSpriteSet.cs
+++ b/AGSUnpacker.Lib/Graphics/AGSSpriteSet.cs
@@ -763,7 +763,7 @@ namespace AGSUnpacker.Lib.Graphics
           throw new InvalidDataException($"Sprite {index} has palette colors, but palette format {format} is unknown");
 
         byte[] buffer = reader.ReadBytes(colors * paletteFormat.Value.GetBytesPerPixel());
-        return Palette.FromBuffer(buffer, paletteFormat.Value);
+        return Palette.FromBuffer(buffer, paletteFormat.Value, discardAlpha: false);
       }
 
       return null;

--- a/AGSUnpacker.Lib/Graphics/AGSSpriteSet.cs
+++ b/AGSUnpacker.Lib/Graphics/AGSSpriteSet.cs
@@ -200,16 +200,16 @@ namespace AGSUnpacker.Lib.Graphics
       return AGSCompression.WriteLZ77(buffer);
     }
 
-    private static byte[] DecompressRLE(BinaryReader reader, long sizeCompressed, long sizeUncompressed, int bytesPerPixel)
+    private static byte[] DecompressRLE(BinaryReader reader, long sizeUncompressed, int bytesPerPixel)
     {
       switch (bytesPerPixel)
       {
         case 1:
-          return AGSCompression.ReadRLE8(reader, sizeCompressed, sizeUncompressed);
+          return AGSCompression.ReadRLE8(reader, sizeUncompressed);
         case 2:
-          return AGSCompression.ReadRLE16(reader, sizeCompressed, sizeUncompressed);
+          return AGSCompression.ReadRLE16(reader, sizeUncompressed);
         case 4:
-          return AGSCompression.ReadRLE32(reader, sizeCompressed, sizeUncompressed);
+          return AGSCompression.ReadRLE32(reader, sizeUncompressed);
 
         default:
           throw new InvalidDataException("Unknown bytesPerPixel value is encountered!");
@@ -703,7 +703,7 @@ namespace AGSUnpacker.Lib.Graphics
       byte[] pixels;
       if (compression == CompressionType.RLE)
         //NOTE(adm244): double check 'bytesPerPixel' value if sprite is indexed
-        pixels = DecompressRLE(reader, size, sizeUncompressed, bytesPerPixel);
+        pixels = DecompressRLE(reader, sizeUncompressed, bytesPerPixel);
       else if (compression == CompressionType.LZW)
         pixels = DecompressLZW(reader, sizeUncompressed);
       else if (compression == CompressionType.Uncompressed)

--- a/AGSUnpacker.Lib/Graphics/Extensions/SpriteFormatExtension.cs
+++ b/AGSUnpacker.Lib/Graphics/Extensions/SpriteFormatExtension.cs
@@ -1,0 +1,24 @@
+﻿using AGSUnpacker.Graphics.Formats;
+
+namespace AGSUnpacker.Lib.Graphics.Extensions
+{
+  public static partial class SpriteFormatExtension
+  {
+    public static PixelFormat? ToPixelFormat(this SpriteFormat format)
+    {
+      switch (format)
+      {
+        case SpriteFormat.PaletteRGB565:
+          return PixelFormat.Rgb565;
+        case SpriteFormat.PaletteRGB24:
+          return PixelFormat.Rgb24;
+        case SpriteFormat.PaletteARGB32:
+          return PixelFormat.Argb32;
+
+        case SpriteFormat.Default:
+        default:
+          return null;
+      }
+    }
+  }
+}

--- a/AGSUnpacker.Lib/Graphics/SpriteSetHeader.cs
+++ b/AGSUnpacker.Lib/Graphics/SpriteSetHeader.cs
@@ -6,41 +6,57 @@ using AGSUnpacker.Graphics;
 
 namespace AGSUnpacker.Lib.Graphics
 {
+  public enum SpriteFormat
+  {
+    Unknown = -1,
+    Default = 0,
+    PaletteRGB24 = 32,
+    PaletteARGB32 = 33,
+    PaletteRGB565 = 34,
+  }
+
   public enum CompressionType
   {
     Unknown = -1,
     Uncompressed = 0,
     RLE = 1,
+    LZW = 2,
   }
 
   public class SpriteSetHeader
   {
     public static readonly string FileName = "header.bin";
 
+    public static readonly int MetaVersion = 2;
+    public static readonly int MetaSignature = 0x4402;
+
     public static readonly int DefaultVersion = 6;
     public static readonly CompressionType DefaultCompression = CompressionType.Uncompressed;
     public static readonly uint DefaultFileID = 0xDEADBEEF;
     public static readonly int DefaultSpritesCount = 0;
     public static readonly Palette DefaultPalette = AGSSpriteSet.DefaultPalette;
+    public static readonly int DefaultStoreFlags = 0;
 
     public int Version { get; private set; }
     public CompressionType Compression { get; private set; }
     public uint FileID { get; private set; }
     public int SpritesCount { get; private set; }
     public Palette Palette { get; private set; }
+    public int StoreFlags { get; private set; }
 
     private SpriteSetHeader()
-      : this(DefaultVersion, DefaultCompression, DefaultFileID, DefaultSpritesCount, DefaultPalette)
+      : this(DefaultVersion, DefaultCompression, DefaultFileID, DefaultSpritesCount, DefaultPalette, DefaultStoreFlags)
     {
     }
 
-    public SpriteSetHeader(int version, CompressionType compression, uint fileID, int spritesCount, Palette palette)
+    public SpriteSetHeader(int version, CompressionType compression, uint fileID, int spritesCount, Palette palette, int storeFlags)
     {
       Version = version;
       Compression = compression;
       FileID = fileID;
       SpritesCount = spritesCount;
       Palette = palette;
+      StoreFlags = storeFlags;
     }
 
     public static SpriteSetHeader ReadFromFile(string filepath)
@@ -51,7 +67,15 @@ namespace AGSUnpacker.Lib.Graphics
       {
         using (BinaryReader reader = new BinaryReader(stream, Encoding.Latin1))
         {
-          header.Version = reader.ReadInt16();
+          int versionMeta = 1;
+          
+          int version = reader.ReadInt16();
+          if (version == MetaSignature)
+          {
+            versionMeta = reader.ReadByte();
+            version = reader.ReadInt16();
+          }
+          header.Version = version;
 
           header.Compression = CompressionType.Unknown;
           byte compressionType = reader.ReadByte();
@@ -60,6 +84,10 @@ namespace AGSUnpacker.Lib.Graphics
 
           header.FileID = reader.ReadUInt32();
           header.SpritesCount = reader.ReadUInt16();
+
+          header.StoreFlags = 0;
+          if (versionMeta >= 2)
+            header.StoreFlags = reader.ReadByte();
 
           if (header.Version < 5)
             header.Palette = AGSGraphics.ReadPalette(reader);
@@ -77,10 +105,14 @@ namespace AGSUnpacker.Lib.Graphics
       {
         using (BinaryWriter writer = new BinaryWriter(stream, Encoding.Latin1))
         {
+          writer.Write((Int16)MetaSignature);
+          writer.Write((byte)MetaVersion);
+
           writer.Write((UInt16)Version);
           writer.Write((byte)Compression);
           writer.Write((UInt32)FileID);
           writer.Write((UInt16)SpritesCount);
+          writer.Write((byte)StoreFlags);
 
           if (Version < 5)
             AGSGraphics.WritePalette(writer, Palette);

--- a/AGSUnpacker.Lib/Room/AGSRoom.cs
+++ b/AGSUnpacker.Lib/Room/AGSRoom.cs
@@ -126,7 +126,8 @@ namespace AGSUnpacker.Lib.Room
 
       while (true)
       {
-        ExtensionBlock.BlockType blockType = ExtensionBlock.ReadSingle(reader, ReadRoomExtensionBlock);
+        ExtensionBlock.BlockType blockType = ExtensionBlock.ReadSingle(reader, ReadRoomExtensionBlock,
+          ExtensionBlock.Options.Id8 | ExtensionBlock.Options.Size64);
         BlockType roomBlockType = (BlockType)blockType;
 
         if (roomBlockType == BlockType.EndOfFile)
@@ -182,7 +183,8 @@ namespace AGSUnpacker.Lib.Room
           if (roomVersion >= 33)
           {
             if (Options.Count > 0)
-              ExtensionBlock.WriteSingle(writer, "ext_sopts", WriteRoomExtensionBlock);
+              ExtensionBlock.WriteSingle(writer, "ext_sopts", WriteRoomExtensionBlock,
+                ExtensionBlock.Options.Id8 | ExtensionBlock.Options.Size64);
           }
 
           WriteRoomBlock(writer, roomVersion, BlockType.EndOfFile);

--- a/AGSUnpacker.Lib/Shared/FormatExtensions/ExtensionBlock.cs
+++ b/AGSUnpacker.Lib/Shared/FormatExtensions/ExtensionBlock.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+
+using AGSUnpacker.Shared.Extensions;
+
+namespace AGSUnpacker.Lib.Shared.FormatExtensions
+{
+  public static class ExtensionBlock
+  {
+    public static BlockType ReadSingle(BinaryReader reader, Func<BinaryReader, string, long, bool> readData)
+    {
+      BlockType blockType = (BlockType)reader.ReadByte();
+      if (!Enum.IsDefined(blockType) || blockType < 0)
+        return blockType;
+
+      if (blockType == BlockType.EndOfFile)
+        return BlockType.EndOfFile;
+
+      string id = reader.ReadFixedCString(16);
+      long size = reader.ReadInt64();
+
+      long blockEnd = reader.BaseStream.Position + size;
+
+      if (!readData(reader, id, size))
+      {
+        //NOTE(adm244): skip extension block if it cannot be parsed
+        Debug.Assert(false, "Extension block cannot be processed!");
+        reader.BaseStream.Seek(blockEnd, SeekOrigin.Begin);
+        return BlockType.InvalidData;
+      }
+
+      return BlockType.Extension;
+    }
+
+    public static void WriteSingle(BinaryWriter writer, string id, Func<BinaryWriter, string, bool> writeData)
+    {
+      writer.Write((byte)BlockType.Extension);
+      writer.WriteFixedString(id, 16);
+
+      long blockStartPreSize = writer.BaseStream.Position;
+
+      //NOTE(adm244): a placeholder for an actual value
+      writer.Write((UInt64)0xDEADBEEF_DEADBEEF);
+
+      long blockStart = writer.BaseStream.Position;
+
+      if (!writeData(writer, id))
+        throw new InvalidDataException($"Cannot write extension block '{id}'!");
+
+      long blockEnd = writer.BaseStream.Position;
+      long blockLength = blockEnd - blockStart;
+      Debug.Assert(blockLength < Int64.MaxValue);
+
+      writer.BaseStream.Seek(blockStartPreSize, SeekOrigin.Begin);
+      writer.Write((Int64)blockLength);
+      writer.BaseStream.Seek(blockEnd, SeekOrigin.Begin);
+    }
+
+    public enum BlockType
+    {
+      InvalidData = -1,
+
+      Extension = 0x00,
+      EndOfFile = 0xFF
+    }
+  }
+}

--- a/AGSUnpacker.Lib/Shared/FormatExtensions/ExtensionBlock.cs
+++ b/AGSUnpacker.Lib/Shared/FormatExtensions/ExtensionBlock.cs
@@ -57,6 +57,27 @@ namespace AGSUnpacker.Lib.Shared.FormatExtensions
       writer.BaseStream.Seek(blockEnd, SeekOrigin.Begin);
     }
 
+    public static bool ReadMultiple(BinaryReader reader, Func<BinaryReader, string, long, bool> readData)
+    {
+      bool result = true;
+
+      while (true)
+      {
+        BlockType blockType = ReadSingle(reader, readData);
+
+        if (!Enum.IsDefined(blockType) || blockType < 0)
+          throw new InvalidDataException($"Unknown extension block '{blockType}' encountered in game data!");
+
+        if (blockType == BlockType.InvalidData)
+          result = false;
+
+        if (blockType == BlockType.EndOfFile)
+          break;
+      }
+
+      return result;
+    }
+
     public enum BlockType
     {
       InvalidData = -1,

--- a/AGSUnpacker.Lib/Translation/AGSTranslation.cs
+++ b/AGSUnpacker.Lib/Translation/AGSTranslation.cs
@@ -4,16 +4,18 @@ using System.Diagnostics;
 using System.IO;
 using System.Text;
 
+using AGSUnpacker.Lib.Shared.FormatExtensions;
 using AGSUnpacker.Shared.Extensions;
 
 namespace AGSUnpacker.Lib.Translation
 {
   public class AGSTranslation
   {
-    private static readonly string TRA_SIGNATURE = "AGSTranslation\x0";
+    private const string TRA_SIGNATURE = "AGSTranslation\x0";
 
-    public static readonly string TRS_TAG_GAMEID = "//#GameId=";
-    public static readonly string TRS_TAG_GAMENAME = "//#GameName=";
+    public const string TRS_TAG_GAMEID = "//#GameId=";
+    public const string TRS_TAG_GAMENAME = "//#GameName=";
+    public const string TRS_TAG_ENCODING = "//#Encoding=";
 
     // FIXME(adm244): temporary? public
     public List<string> OriginalLines { get; set; }
@@ -23,6 +25,19 @@ namespace AGSUnpacker.Lib.Translation
     public string GameName { get; private set; }
 
     public Dictionary<string, string> Options;
+    
+    public string TextEncoding
+    {
+      get
+      {
+        if (Options.ContainsKey("encoding"))
+          return Options["encoding"];
+
+        return "ASCII";
+      }
+
+      set => Options["encoding"] = value;
+    }
 
     public AGSTranslation()
     {
@@ -80,6 +95,10 @@ namespace AGSUnpacker.Lib.Translation
           //TODO(adm244): implement settings block
           //WriteBlock(writer, BlockType.Settings);
 
+          if (Options.Count > 0)
+            ExtensionBlock.WriteSingle(writer, "ext_sopts", WriteExtensionBlock,
+              ExtensionBlock.Options.Id32 | ExtensionBlock.Options.Size64);
+
           WriteBlock(writer, BlockType.End);
         }
       }
@@ -112,8 +131,8 @@ namespace AGSUnpacker.Lib.Translation
               writer.WriteEncryptedCString(TranslatedLines[i]);
             }
 
-            //NOTE(adm244): write empty strings so parser knows this block has ended
-            // no idea why they just didn't use a block size value...
+            //NOTE(adm244): write empty strings so parser knows this block has ended;
+            // no idea why they just don't use a block size value...
             writer.WriteEncryptedCString("");
             writer.WriteEncryptedCString("");
           } break;
@@ -154,45 +173,32 @@ namespace AGSUnpacker.Lib.Translation
 
           for (; ; )
           {
-            Int32 blockType = reader.ReadInt32();
+            //NOTE(adm244): there are two places in ags source that supposedly
+            // write translation files: cpp code and csharp code;
+            // "cpp" writes size as 32-bit integer and has a bug (yep) in calculation
+            // that makes it 4-bytes short, but luckily is never called from anywhere;
+            // "csharp" writes size as 64-bit integer, hardcodes all values and
+            // is actually being used for writing tra files.
+            //
+            // Thus, we read block size as 64-bit integer here
+            ExtensionBlock.BlockType extensionBlockType = ExtensionBlock.ReadSingle(reader, ReadExtensionBlock,
+              ExtensionBlock.Options.Id32 | ExtensionBlock.Options.Size64);
+            BlockType blockType = (BlockType)extensionBlockType;
 
-            if (blockType == (int)BlockType.End)
+            if (blockType == BlockType.End)
               break;
 
-            if (blockType == (int)BlockType.Extension)
-            {
-              string id = reader.ReadFixedCString(16);
+            //FIXME(adm244): well, this check is weird...
+            bool isExtensionBlock = Enum.IsDefined(extensionBlockType) && extensionBlockType >= 0;
+            bool isTranslationBlock = Enum.IsDefined(blockType);
 
-              //NOTE(adm244): there are two places in ags source that supposedly
-              // write translation files: cpp code and csharp code;
-              // "cpp" writes size as 32-bit integer and has a bug (yep) in calculation
-              // that makes it 4-bytes short, but luckily is never called from anywhere;
-              // "csharp" writes size as 64-bit integer, hardcodes all values and
-              // actually is being used for writing tra files.
-              //
-              // Thus, we read 64-bit integer here (and are not using ExtensionBlock)
-              long size = reader.ReadInt64();
+            if (isExtensionBlock)
+              continue;
 
-              long blockEnd = reader.BaseStream.Position + size;
-              if (!ReadExtensionBlock(reader, id, size))
-              {
-                //NOTE(adm244): skip extension block if it cannot be parsed
-                Debug.Assert(false, $"Cannot read translation extension block '{blockType}'!");
-                reader.BaseStream.Seek(blockEnd, SeekOrigin.Begin);
-              }
-            }
-            else
-            {
-              long size = reader.ReadInt32();
+            if (!isTranslationBlock)
+              throw new InvalidDataException($"Unknown block type encountered: {blockType}");
 
-              long blockEnd = reader.BaseStream.Position + size;
-              if (!ReadTranslationBlock(reader, (BlockType)blockType, size))
-              {
-                //NOTE(adm244): skip block if it cannot be parsed
-                Debug.Assert(false, $"Cannot read translation block '{blockType}'!");
-                reader.BaseStream.Seek(blockEnd, SeekOrigin.Begin);
-              }
-            }
+            ReadTranslationBlock(reader, blockType);
           }
         }
       }
@@ -214,6 +220,20 @@ namespace AGSUnpacker.Lib.Translation
       return true;
     }
 
+    //FIXME(adm244): duplicate of AGSRoom.WriteOptionsExtensionBlock
+    private bool WriteOptionsExtensionBlock(BinaryWriter writer)
+    {
+      writer.Write((Int32)Options.Count);
+
+      foreach (var option in Options)
+      {
+        writer.WritePrefixedString32(option.Key);
+        writer.WritePrefixedString32(option.Value);
+      }
+
+      return true;
+    }
+
     private bool ReadExtensionBlock(BinaryReader reader, string id, long size)
     {
       switch (id)
@@ -227,9 +247,23 @@ namespace AGSUnpacker.Lib.Translation
       }
     }
 
-    private bool ReadTranslationBlock(BinaryReader reader, BlockType type, long size)
+    private bool WriteExtensionBlock(BinaryWriter writer, string id)
+    {
+      switch (id)
+      {
+        case "ext_sopts":
+          return WriteOptionsExtensionBlock(writer);
+
+        default:
+          Debug.Assert(false, $"Unknown extension block '{id}' encountered!");
+          return false;
+      }
+    }
+
+    private bool ReadTranslationBlock(BinaryReader reader, BlockType type)
     {
       //TODO(adm244): check size
+      long size = reader.ReadInt32();
 
       switch (type)
       {
@@ -288,6 +322,10 @@ namespace AGSUnpacker.Lib.Translation
               {
                 translation.GameName = line.Substring(TRS_TAG_GAMENAME.Length);
               }
+              else if (line.StartsWith(TRS_TAG_ENCODING))
+              {
+                translation.TextEncoding = line.Substring(TRS_TAG_ENCODING.Length);
+              }
 
               continue;
             }
@@ -332,6 +370,7 @@ namespace AGSUnpacker.Lib.Translation
 
           writer.WriteLine("{0}{1}", TRS_TAG_GAMEID, GameID);
           writer.WriteLine("{0}{1}", TRS_TAG_GAMENAME, GameName);
+          writer.WriteLine("{0}{1}", TRS_TAG_ENCODING, TextEncoding);
 
           for (int i = 0; i < OriginalLines.Count; ++i)
           {
@@ -345,7 +384,6 @@ namespace AGSUnpacker.Lib.Translation
     private enum BlockType
     {
       End = -1,
-      Extension = 0,
       Content = 1,
       Header = 2,
       Settings = 3,

--- a/AGSUnpacker.Lib/Utils/AGSCompression.cs
+++ b/AGSUnpacker.Lib/Utils/AGSCompression.cs
@@ -6,13 +6,12 @@ namespace AGSUnpacker.Lib.Utils
 {
   internal static class AGSCompression
   {
-    internal static byte[] ReadRLE8(BinaryReader reader, long sizeCompressed, long sizeUncompressed)
+    internal static byte[] ReadRLE8(BinaryReader reader, long sizeUncompressed)
     {
       byte[] buffer = new byte[sizeUncompressed];
       int positionImage = 0;
 
-      long positionBase = reader.BaseStream.Position;
-      for (long n = 0; n < sizeCompressed; n = (reader.BaseStream.Position - positionBase))
+      while (positionImage < sizeUncompressed)
       {
         sbyte control = (sbyte)reader.ReadByte();
         if (control == -128)
@@ -44,13 +43,12 @@ namespace AGSUnpacker.Lib.Utils
       return buffer;
     }
 
-    internal static byte[] ReadRLE16(BinaryReader reader, long sizeCompressed, long sizeUncompressed)
+    internal static byte[] ReadRLE16(BinaryReader reader, long sizeUncompressed)
     {
       byte[] buffer = new byte[sizeUncompressed];
       int positionImage = 0;
 
-      long positionBase = reader.BaseStream.Position;
-      for (long n = 0; n < sizeCompressed; n = (reader.BaseStream.Position - positionBase))
+      while (positionImage < sizeUncompressed)
       {
         sbyte control = (sbyte)reader.ReadByte();
         if (control == -128)
@@ -85,13 +83,12 @@ namespace AGSUnpacker.Lib.Utils
       return buffer;
     }
 
-    internal static byte[] ReadRLE32(BinaryReader reader, long sizeCompressed, long sizeUncompressed)
+    internal static byte[] ReadRLE32(BinaryReader reader, long sizeUncompressed)
     {
       byte[] buffer = new byte[sizeUncompressed];
       int positionImage = 0;
 
-      long positionBase = reader.BaseStream.Position;
-      for (long n = 0; n < sizeCompressed; n = (reader.BaseStream.Position - positionBase))
+      while (positionImage < sizeUncompressed)
       {
         sbyte control = (sbyte)reader.ReadByte();
         if (control == -128)
@@ -417,42 +414,44 @@ namespace AGSUnpacker.Lib.Utils
       return output;
     }
 
-    internal static byte[] ReadAllegro(BinaryReader reader, int width, int height)
-    {
-      // TODO(adm244): see if we can use ReadRLE8() here
-      using (MemoryStream stream = new MemoryStream())
-      {
-        for (int y = 0; y < height; ++y)
-        {
-          int pixelsRead = 0;
-          while (pixelsRead < width)
-          {
-            sbyte index = (sbyte)reader.ReadByte();
-            if (index == -128) index = 0;
+    // NOTE(adm244): deprecated
+    //internal static byte[] ReadAllegro(BinaryReader reader, int width, int height)
+    //{
+    //  // TODO(adm244): see if we can use ReadRLE8() here
+    //  using (MemoryStream stream = new MemoryStream())
+    //  {
+    //    for (int y = 0; y < height; ++y)
+    //    {
+    //      int pixelsRead = 0;
+    //      while (pixelsRead < width)
+    //      {
+    //        sbyte index = (sbyte)reader.ReadByte();
+    //        if (index == -128) index = 0;
+    //
+    //        if (index < 0)
+    //        {
+    //          int count = (1 - index);
+    //          byte value = reader.ReadByte();
+    //
+    //          while ((count--) > 0)
+    //            stream.WriteByte(value);
+    //
+    //          pixelsRead += (1 - index);
+    //        }
+    //        else
+    //        {
+    //          byte[] buffer = reader.ReadBytes(index + 1);
+    //          stream.Write(buffer, 0, buffer.Length);
+    //          pixelsRead += (index + 1);
+    //        }
+    //      }
+    //    }
+    //
+    //    return stream.ToArray();
+    //  }
+    //}
 
-            if (index < 0)
-            {
-              int count = (1 - index);
-              byte value = reader.ReadByte();
-
-              while ((count--) > 0)
-                stream.WriteByte(value);
-
-              pixelsRead += (1 - index);
-            }
-            else
-            {
-              byte[] buffer = reader.ReadBytes(index + 1);
-              stream.Write(buffer, 0, buffer.Length);
-              pixelsRead += (index + 1);
-            }
-          }
-        }
-
-        return stream.ToArray();
-      }
-    }
-
+    // TODO(adm244): rename to something like "WriteRLE8Chuncked"?
     internal static void WriteAllegro(BinaryWriter writer, byte[] buffer, int width, int height)
     {
       for (int y = 0; y < height; ++y)

--- a/AGSUnpacker.Lib/Utils/AGSCompression.cs
+++ b/AGSUnpacker.Lib/Utils/AGSCompression.cs
@@ -336,7 +336,7 @@ namespace AGSUnpacker.Lib.Utils
       }
     }
 
-    internal static byte[] ReadLZ77(BinaryReader reader, long sizeUncompressed, int bytesPerPixel, out int width, out int height)
+    internal static byte[] ReadLZ77(BinaryReader reader, long sizeUncompressed)
     {
       /*
        * AGS background image decompression algorithm:
@@ -414,16 +414,7 @@ namespace AGSUnpacker.Lib.Utils
         }
       }
 
-      //TODO(adm244): get from DTA info
-      //TODO(adm244): try to remember what this TODO means...
-      //TODO(adm244): consider using a utils function to convert from a byte buffer to int32
-      width = ((output[3] << 24) | (output[2] << 16) | (output[1] << 8) | output[0]) / bytesPerPixel;
-      height = ((output[7] << 24) | (output[6] << 16) | (output[5] << 8) | output[4]);
-
-      byte[] pixels = new byte[output.Length - 8];
-      Array.Copy(output, 8, pixels, 0, pixels.Length);
-
-      return pixels;
+      return output;
     }
 
     internal static byte[] ReadAllegro(BinaryReader reader, int width, int height)

--- a/AGSUnpacker.Lib/Utils/AGSCompression.cs
+++ b/AGSUnpacker.Lib/Utils/AGSCompression.cs
@@ -468,7 +468,7 @@ namespace AGSUnpacker.Lib.Utils
     //NOTE(adm244): it performs worse than the original (i.e. low speed) but
     // the file size is actually smaller since we don't interrupt the sequence
     //TODO(adm244): write a faster implementation
-    internal static byte[] LZ77Compress(byte[] buffer)
+    internal static byte[] WriteLZ77(byte[] buffer)
     {
       using (MemoryStream stream = new MemoryStream(buffer.Length))
       {

--- a/AGSUnpacker.Shared/AGSUnpacker.Shared.projitems
+++ b/AGSUnpacker.Shared/AGSUnpacker.Shared.projitems
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\BinaryReaderExtension.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\BinaryWriterExtension.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ReadOnlySubStream.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utils\AGSStringUtils.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utils\Encryption\AGSEncryption.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utils\IEEE754Utils.cs" />

--- a/AGSUnpacker.Shared/Extensions/BinaryReaderExtension.cs
+++ b/AGSUnpacker.Shared/Extensions/BinaryReaderExtension.cs
@@ -44,8 +44,11 @@ namespace AGSUnpacker.Shared.Extensions
     public static string ReadEncryptedCString(this BinaryReader reader)
     {
       Int32 length = reader.ReadInt32();
-      if ((length <= 0) || (length > AGSStringUtils.MaxCStringLength))
+      if ((length < 0) || (length > AGSStringUtils.MaxCStringLength))
         throw new IndexOutOfRangeException();
+
+      if (length == 0)
+        return string.Empty;
 
       //NOTE(adm244): ASCII ReadChars is not reliable in this case since it replaces bytes > 0x7F
       // https://referencesource.microsoft.com/#mscorlib/system/text/asciiencoding.cs,879

--- a/AGSUnpacker.Shared/Extensions/BinaryWriterExtension.cs
+++ b/AGSUnpacker.Shared/Extensions/BinaryWriterExtension.cs
@@ -51,6 +51,7 @@ namespace AGSUnpacker.Shared.Extensions
       writer.Write((char[])buffer);
     }
 
+    //FIXME(adm244): inconsistency in naming, this shouldn't add extra byte(!)
     public static void WriteFixedCString(this BinaryWriter writer, string text, int length)
     {
       char[] buffer = new char[length + 1];

--- a/AGSUnpacker.Shared/ReadOnlySubStream.cs
+++ b/AGSUnpacker.Shared/ReadOnlySubStream.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.IO;
+
+namespace AGSUnpacker.Shared
+{
+  internal class ReadOnlySubStream : Stream
+  {
+    private Stream _superStream;
+    private long _superStreamOffsetStart;
+    private long _superStreamOffsetEnd;
+    private long _superStreamPosition;
+
+    public ReadOnlySubStream(Stream superStream, long offset, long length)
+    {
+      if (superStream == null)
+        throw new ArgumentNullException(nameof(superStream));
+
+      _superStream = superStream;
+      _superStreamOffsetStart = offset;
+      _superStreamOffsetEnd = offset + length;
+      _superStreamPosition = offset;
+    }
+
+    public override bool CanRead => _superStream.CanRead;
+
+    public override bool CanSeek => false;
+
+    public override bool CanWrite => false;
+
+    public override long Length => _superStreamOffsetEnd - _superStreamOffsetStart;
+
+    public override long Position
+    {
+      get => _superStreamPosition - _superStreamOffsetStart;
+      set => throw new NotSupportedException();
+    }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+      if (_superStream.Position != _superStreamPosition)
+        _superStream.Seek(_superStreamPosition, SeekOrigin.Begin);
+
+      if (_superStreamPosition + count > _superStreamOffsetEnd)
+        count = (int)(_superStreamOffsetEnd - _superStreamPosition);
+
+      int bytesRead = _superStream.Read(buffer, offset, count);
+
+      _superStreamPosition += bytesRead;
+
+      return bytesRead;
+    }
+
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+      throw new NotSupportedException();
+    }
+
+    public override void SetLength(long value)
+    {
+      throw new NotSupportedException();
+    }
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+      throw new NotSupportedException();
+    }
+
+    public override void Flush()
+    {
+      throw new NotSupportedException();
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+      base.Dispose(disposing);
+    }
+  }
+}

--- a/AGSUnpacker.Shared/Utils/AGSStringUtils.cs
+++ b/AGSUnpacker.Shared/Utils/AGSStringUtils.cs
@@ -49,6 +49,13 @@ namespace AGSUnpacker.Shared.Utils
         return new string(p);
     }
 
+    public static unsafe string ConvertCStringMaybe(byte[] buffer)
+    {
+      char[] characters = Encoding.GetChars(buffer);
+      fixed (char* p = &characters[0])
+        return new string(p);
+    }
+
     public static string ConvertToString(byte[] buffer)
     {
       Debug.Assert(buffer != null);

--- a/AGSUnpacker.Shared/Utils/Encryption/AGSEncryption.cs
+++ b/AGSUnpacker.Shared/Utils/Encryption/AGSEncryption.cs
@@ -44,7 +44,11 @@
     public static unsafe string DecryptAvis(byte[] bufferEncrypted)
     {
       byte[] bufferDecrypted = DecryptAvisBuffer(bufferEncrypted);
-      return AGSStringUtils.ConvertCString(bufferDecrypted);
+      //NOTE(adm244): since around 3.6.0.6 null-terminator here is gone,
+      // but to support older versions we still expect it (it's just not required);
+      //
+      // that's decryption... whatchagonnado with encryption part? D:
+      return AGSStringUtils.ConvertCStringMaybe(bufferDecrypted);
     }
 
     public static byte[] EncryptAvisBuffer(byte[] bufferDecrypted)
@@ -67,6 +71,7 @@
       for (int i = 0; i < text.Length; ++i)
         buffer[i] = (byte)text[i];
 
+      //NOTE(adm244): oh, really?
       //NOTE(adm244): string must be null-terminated before encryption
       buffer[text.Length] = 0;
 

--- a/AGSUnpacker.Shared/Utils/Encryption/AGSEncryption.cs
+++ b/AGSUnpacker.Shared/Utils/Encryption/AGSEncryption.cs
@@ -81,7 +81,8 @@
         //NOTE(adm244): convert char to byte before subtracting, so we underflow properly
         bufferDecrypted[i] = (byte)((byte)textEncrypted[i] - salt);
 
-      return AGSStringUtils.ConvertCString(bufferDecrypted);
+      //return AGSStringUtils.ConvertCString(bufferDecrypted);
+      return AGSStringUtils.ConvertToString(bufferDecrypted);
     }
   }
 }

--- a/AGSUnpacker.UI/AGSUnpacker.UI.csproj
+++ b/AGSUnpacker.UI/AGSUnpacker.UI.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <StartupObject>AGSUnpacker.UI.App</StartupObject>
     <AssemblyName>AGSUnpacker</AssemblyName>

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ A program for unpacking/repacking AGS games assets/sprites, extracting text for 
 Written in C#.
 
 ## Supported versions
-Currently it supports games made with AGS 2.54 and newer. Latest supported AGS version is 3.5.0.
+Currently it supports games made with AGS 2.54 and newer. Latest supported AGS version is 3.6.0.
 
 ## Third-party requirements
-* [.NET 5](https://dotnet.microsoft.com/en-us/download/dotnet/5.0)
+* [.NET 6](https://dotnet.microsoft.com/en-us/download/dotnet/6.0/runtime)
 
 **AGSUnpacker.UI:**
 * [Microsoft.Toolkit.Mvvm](https://www.nuget.org/packages/Microsoft.Toolkit.Mvvm)


### PR DESCRIPTION
* Migration to .NET 6 (since people had troubles installing and running now outdated .NET 5)
* Added support for user packed files in CLib file
* Added folders support for CLib file
* Assets extraction refactored to use substreams
* Added support for acsprset v12 (indexed sprites, LZW compression)
* Fixed RLE decompression issue introduced in AGS 3.6.0
* Added support for extension blocks

This should be enough to claim that AGSUnpacker now supports AGS 3.6.0.